### PR TITLE
Update cladetime function names

### DIFF
--- a/get_covid_clade_counts.py
+++ b/get_covid_clade_counts.py
@@ -26,8 +26,7 @@ from pathlib import Path
 import logging
 from datetime import datetime, timedelta, timezone
 
-from cladetime import CladeTime  # type: ignore
-from cladetime.util.sequence import filter_covid_genome_metadata, get_clade_counts  # type: ignore
+from cladetime import CladeTime, sequence  # type: ignore
 
 # Log to stdout
 logger = logging.getLogger(__name__)
@@ -75,10 +74,11 @@ def main(as_of: str | None = None):
     # get Polars LazyFrame to Nextstrain sequence metadata
     lf_metadata = ct.sequence_metadata
 
-    logger.info("filter_covid_genome_metadata")
-    lf_metadata_filtered = filter_covid_genome_metadata(lf_metadata)
+    logger.info("filter_metadata")
+    lf_metadata_filtered = sequence.filter_metadata(lf_metadata)
     logger.info("get_clade_counts")
-    counts = get_clade_counts(lf_metadata_filtered)
+    counts = sequence.summarize_clades(lf_metadata_filtered, group_by=["clade", "date", "location"])
+
 
     output_file = f"data/{as_of}_covid_clade_counts.parquet"
     logger.info("collecting clade counts")


### PR DESCRIPTION
This is a small update to reflect recent changes to the `cladetime` API. While those changes are backwards compatible, I'd like to remove the "backwards" workarounds to prevent confusion in the `cladetime` code base.

I did the following to test this change:

- ran this command against the branch: `uv run get_covid_clade_counts.py --as-of=2024-09-23`, adding a `_test` suffix to the name
- ran the same command against the main branch
- verified that the output files are equal:

```python
import polars as pl
from polars.testing import assert_frame_equal

old = pl.read_parquet("data/2024-09-23_covid_clade_counts.parquet")
new = pl.read_parquet("data/2024-09-23_covid_clade_counts_test.parquet")
assert_frame_equal(new, old, check_row_order=False, check_column_order=False)
```