### PR TITLE
Fix comment about AWS account number

### DIFF
--- a/.github/workflows/get-covid-clade-counts.yaml
+++ b/.github/workflows/get-covid-clade-counts.yaml
@@ -11,7 +11,7 @@ on:
         default: $(date +'%Y-%m-%d')
 
 env:
-  # Hubverse AWS account number
+  # Reich Lab AWS account number
   AWS_ACCOUNT: 312560106906
 
 permissions:


### PR DESCRIPTION
To prevent future confusion, let the record state that 312560106906 is the Reich Lab AWS account, not the Hubverse AWS account